### PR TITLE
Sub-window padding

### DIFF
--- a/src/staple_tracker.cpp
+++ b/src/staple_tracker.cpp
@@ -160,6 +160,13 @@ void STAPLE_TRACKER::getSubwindow(const cv::Mat &im, cv::Point_<float> centerCoo
     cv::Rect roiRect(lefttopLimit, rightbottomLimit);
 
     im(roiRect).copyTo(subWindow);
+	
+	int top = lefttopLimit.y - lefttop.y;
+	int bottom = rightbottom.y - rightbottomLimit.y + 1;
+	int left = lefttopLimit.x - lefttop.x;
+	int right = rightbottom.x - rightbottomLimit.x + 1;
+
+	cv::copyMakeBorder(subWindow, subWindow, top, bottom, left, right, cv::BORDER_REPLICATE);
 
     // imresize(subWindow, output, model_sz, 'bilinear', 'AntiAliasing', false)
     mexResize(subWindow, output, model_sz, "auto");

--- a/src/staple_tracker.cpp
+++ b/src/staple_tracker.cpp
@@ -161,12 +161,12 @@ void STAPLE_TRACKER::getSubwindow(const cv::Mat &im, cv::Point_<float> centerCoo
 
     im(roiRect).copyTo(subWindow);
 	
-	int top = lefttopLimit.y - lefttop.y;
-	int bottom = rightbottom.y - rightbottomLimit.y + 1;
-	int left = lefttopLimit.x - lefttop.x;
-	int right = rightbottom.x - rightbottomLimit.x + 1;
-
-	cv::copyMakeBorder(subWindow, subWindow, top, bottom, left, right, cv::BORDER_REPLICATE);
+    int top = lefttopLimit.y - lefttop.y;
+    int bottom = rightbottom.y - rightbottomLimit.y + 1;
+    int left = lefttopLimit.x - lefttop.x;
+    int right = rightbottom.x - rightbottomLimit.x + 1;
+	
+    cv::copyMakeBorder(subWindow, subWindow, top, bottom, left, right, cv::BORDER_REPLICATE);
 
     // imresize(subWindow, output, model_sz, 'bilinear', 'AntiAliasing', false)
     mexResize(subWindow, output, model_sz, "auto");


### PR DESCRIPTION
## This PR

This small PR fixes a bug that appears when the target to be tracked is close to the image border.  
When this is the case the `x,y` coordinates of `lefttop` and `rightbottom` in https://github.com/xuduo35/STAPLE/blob/master/src/staple_tracker.cpp#L139-L147
are either negative or larger than the image size. This is subsequently corrected [here](https://github.com/xuduo35/STAPLE/blob/master/src/staple_tracker.cpp#L149-L162), by truncating coordinates to `0` or to the `image size`. 
A side-effect of this, however, is that the produced template is effectively cropped and thus not well centered on the target any more, causing the tracker to drift after a few frames. 

The solution proposed in this PR is to pad the `cropped` template, so that the target is brought back at its center, as it would be if located away from the image borders. Padding is done by replicating the template's border pixels, however other forms of padding could also be considered. 
