### PR TITLE
Update staple_tracker.cpp

### DIFF
--- a/src/staple_tracker.cpp
+++ b/src/staple_tracker.cpp
@@ -547,7 +547,7 @@ void STAPLE_TRACKER::getFeatureMap(cv::Mat &im_patch, const char *feature_type, 
     cv::Mat grayimg;
 
     if (new_im_patch.channels() > 1) {
-        cv::cvtColor(new_im_patch, grayimg, CV_BGR2GRAY);
+        cv::cvtColor(new_im_patch, grayimg, cv::COLOR_BGR2GRAY);
     } else {
         grayimg = new_im_patch;
     }


### PR DESCRIPTION
latest (4.0) opencv does no more support the old c-api enums, so let's use the proper c++ flag

(nice tracker, btw !)